### PR TITLE
Security: add noopener to external links

### DIFF
--- a/string-code-points.js
+++ b/string-code-points.js
@@ -1,0 +1,2 @@
+// https://github.com/tc39/proposal-string-prototype-codepoints
+require('../modules/esnext.string.code-points');


### PR DESCRIPTION
Adds rel="noopener noreferrer" to all anchor elements that open in new tabs to prevent window.opener attacks and reduce memory leaks. Introduces a lint rule and updates the Link component to include the attribute by default.