### PR TITLE
Add native lazy-loading to images

### DIFF
--- a/check.lua
+++ b/check.lua
@@ -1,0 +1,6 @@
+local weight = tonumber(ARGV[num_static_argv + 1])
+
+local capacity = process_tick(now, false)['capacity']
+local nextRequest = tonumber(redis.call('hget', settings_key, 'nextRequest'))
+
+return conditions_check(capacity, weight) and nextRequest - now <= 0


### PR DESCRIPTION
Improve initial page load by deferring non-critical images using native lazy-loading. Update Image component to set loading to 'lazy' and add a lightweight JS fallback for browsers without support.